### PR TITLE
Write tags as ActiveSupport::TaggedLogging

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -21,7 +21,7 @@ module ActFluentLoggerRails
       return true if severity < @level
       message = (block_given? ? block.call : progname) if message.blank?
       return true if message.blank?
-      @logger.add_message(severity, message)
+      @logger.add_message(severity, "#{tags_text}#{message}")
       true
     end
 


### PR DESCRIPTION
I found that the tags of `config.log_tags` didn't appear when using this gem.
With this fix, they are written as `ActiveSupport::TaggedLogging` does.
