### PR TITLE
fixed incompatible character encodings #13

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -74,12 +74,12 @@ module ActFluentLoggerRails
 
     def add_message(severity, message)
       @severity = severity if @severity < severity
-      @messages << encode_message(message)
-    end
 
-    def encode_message(message)
-      return nil unless message.respond_to? :force_encoding
-      message.force_encoding("UTF-8")
+      if message.encoding == Encoding::UTF_8
+        @messages << message
+      else
+        @messages << message.dup.force_encoding(Encoding::UTF_8)
+      end
     end
 
     def [](key)

--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -74,7 +74,12 @@ module ActFluentLoggerRails
 
     def add_message(severity, message)
       @severity = severity if @severity < severity
-      @messages << message
+      @messages << encode_message(message)
+    end
+
+    def encode_message(message)
+      return nil unless message.respond_to? :force_encoding
+      message.force_encoding("UTF-8")
     end
 
     def [](key)


### PR DESCRIPTION
Fixed https://github.com/actindi/act-fluent-logger-rails/issues/13 `incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)` .

Forced messages' encoding to UTF8 since ruby2.0's default encoding is UTF8.

Please see if this is mergeable..
Thanks!

