### PR TITLE
[Fix #15] Allow logger to log exceptions

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -75,6 +75,11 @@ module ActFluentLoggerRails
     def add_message(severity, message)
       @severity = severity if @severity < severity
 
+      if message.is_a? Exception
+        error_message = message.message + "\n" + message.backtrace.join("\n") + "\n"
+        message = error_message
+      end
+
       if message.encoding == Encoding::UTF_8
         @messages << message
       else


### PR DESCRIPTION
See Issue #15 
I would like to be able to log exceptions, e.g.
```ruby
begin
  raise NoMethodError
rescue Exception => e
  Rails.logger.error e
end
```