### PR TITLE
Add secondary log support and option to flush logs immediately

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -118,11 +118,7 @@ module ActFluentLoggerRails
       end
 
       @fluent_logger.post(@tag, @map)
-
-      if @secondary_log
-        @secondary_log.add(@severity, @map)
-        @secondary_log.flush
-      end
+      @secondary_log.add(@severity, @map) if @secondary_log
 
       @severity = 0
       @messages.clear


### PR DESCRIPTION
This PR adds two features:

1 - The ability to log to a secondary (non-fluentd) logger. Using `ActiveSupport::Logger.broadcast` has various issues, as mentioned here: https://github.com/actindi/act-fluent-logger-rails/issues/19 This is an attempt to get around that.

Example usage: `ActFluentLoggerRails::Logger.new(log_tags: log_tags, secondary_log: Logger.new('log.txt'))`

2 - The ability to flush the log immediately, rather than waiting for the end of a request. This is useful in something like `DelayedJob` where the logs never get flushed otherwise.

Example usage: `ActFluentLoggerRails::Logger.new(flush_immediately: true)`

I'm open to opinions on whether or not this solution is okay, and whether there are any potential problems I'm not seeing.