### PR TITLE
Use message.inspect if message does not have encoding

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -108,6 +108,7 @@ module ActFluentLoggerRails
                  end
       @map[:messages] = messages
       @map[:level] = format_severity(@severity)
+      @map[:severity] = format_severity(@severity)
       @log_tags.each do |k, v|
         @map[k] = case v
                   when Proc

--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -80,6 +80,10 @@ module ActFluentLoggerRails
         message = error_message
       end
 
+      if not message.methods.include? :encoding
+        message = message.inspect
+      end
+
       if message.encoding == Encoding::UTF_8
         @messages << message
       else


### PR DESCRIPTION
For debug level logging a developer may log an object or class without having converted it to a string beforehand. This PR checks that the logged message has an encoding and converts it to the inspected string if not so it can be properly logged.