### PR TITLE
Use message.inspect if message does not have encoding

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -80,6 +80,10 @@ module ActFluentLoggerRails
         message = error_message
       end
 
+      if not message.methods.include? :encoding
+        message = message.inspect
+      end
+
       if message.encoding == Encoding::UTF_8
         @messages << message
       else


### PR DESCRIPTION
When enabling debug level logging, a developer may want to log objects or hashes that haven't been converted to a string already. In the case of messages with no encoding, inspect the log message and log the inspected result to avoid a failure and skipping the message.