### PR TITLE
Add severity as key to log entry metadata

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -104,6 +104,7 @@ module ActFluentLoggerRails
                  end
       @map[:messages] = messages
       @map[:level] = format_severity(@severity)
+      @map[:severity] = format_severity(@severity)
       @log_tags.each do |k, v|
         @map[k] = case v
                   when Proc


### PR DESCRIPTION
Google Cloud Logging only accepts `severity` as a key for log levels. This PR fills that key so it's properly populated in that system.