### PR TITLE
Added settings: parameter to ActFluentLoggerRails::Logger.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ in config/environments/production.rb
 
 Don't use config.log_tags.
 
-## To define where to send messages to, eiter:
+### To define where to send messages to, eiter:
 
-# create config/fluent-logger.yml
+#### create config/fluent-logger.yml
 
     development:
       fluent_host:   '127.0.0.1'
@@ -56,7 +56,7 @@ Don't use config.log_tags.
       tag:           'foo'
       messages_type: 'string'
 
-# set an environment variable FLUENTD_URL
+#### set an environment variable FLUENTD_URL
 
     http://fluentd.example.com:42442/foo?messages_type=string
 
@@ -65,7 +65,7 @@ Don't use config.log_tags.
  * tag: The tag of the Fluentd event.
  * messages_type: The type of log messages. 'string' or 'array'.
 
-# pass a settings object to ActFluentLoggerRails::Logger.new
+#### pass a settings object to ActFluentLoggerRails::Logger.new
 
     config.logger = ActFluentLoggerRails::Logger.
       new(settings: {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ in config/environments/production.rb
 
 Don't use config.log_tags.
 
-create config/fluent-logger.yml
+## To define where to send messages to, eiter:
+
+# create config/fluent-logger.yml
 
     development:
       fluent_host:   '127.0.0.1'
@@ -54,7 +56,7 @@ create config/fluent-logger.yml
       tag:           'foo'
       messages_type: 'string'
 
-or set an environment variable FLUENTD_URL
+# set an environment variable FLUENTD_URL
 
     http://fluentd.example.com:42442/foo?messages_type=string
 
@@ -62,7 +64,17 @@ or set an environment variable FLUENTD_URL
  * fluent_port: The port number of Fluentd.
  * tag: The tag of the Fluentd event.
  * messages_type: The type of log messages. 'string' or 'array'.
-   If it is 'string', the log messages is a String.
+
+# pass a settings object to ActFluentLoggerRails::Logger.new
+
+    config.logger = ActFluentLoggerRails::Logger.
+      new(settings: {
+            host: '127.0.0.1',
+            port: 24224,
+	    tag: 'foo',
+	    messages_type: 'string'})
+
+If it is 'string', the log messages is a String.
 ```
 2013-01-18T15:04:50+09:00 foo {"messages":"Started GET \"/\" for 127.0.0.1 at 2013-01-18 15:04:49 +0900\nProcessing by TopController#index as HTML\nCompleted 200 OK in 635ms (Views: 479.3ms | ActiveRecord: 39.6ms)"],"level":"INFO"}
 ```
@@ -70,6 +82,7 @@ or set an environment variable FLUENTD_URL
 ```
 2013-01-18T15:04:50+09:00 foo {"messages":["Started GET \"/\" for 127.0.0.1 at 2013-01-18 15:04:49 +0900","Processing by TopController#index as HTML","Completed 200 OK in 635ms (Views: 479.3ms | ActiveRecord: 39.6ms)"],"level":"INFO"}
 ```
+
 
 You can add any tags at run time.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ in config/environments/production.rb
 
 Don't use config.log_tags.
 
-### To define where to send messages to, eiter:
+### To define where to send messages to, either:
 
 #### create config/fluent-logger.yml
 
@@ -70,7 +70,7 @@ Don't use config.log_tags.
     config.logger = ActFluentLoggerRails::Logger.
       new(settings: {
             host: '127.0.0.1',
-            port: 24224,
+	    port: 24224,
 	    tag: 'foo',
 	    messages_type: 'string'})
 

--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -11,19 +11,21 @@ module ActFluentLoggerRails
     # Severity label for logging. (max 5 char)
     SEV_LABEL = %w(DEBUG INFO WARN ERROR FATAL ANY)
 
-    def self.new(config_file: Rails.root.join("config", "fluent-logger.yml"), log_tags: {})
+    def self.new(config_file: Rails.root.join("config", "fluent-logger.yml"), log_tags: {}, settings: {})
       Rails.application.config.log_tags = [ ->(request) { request } ] unless log_tags.empty?
-      fluent_config = if ENV["FLUENTD_URL"]
-                        self.parse_url(ENV["FLUENTD_URL"])
-                      else
-                        YAML.load(ERB.new(config_file.read).result)[Rails.env]
-                      end
-      settings = {
-        tag:  fluent_config['tag'],
-        host: fluent_config['fluent_host'],
-        port: fluent_config['fluent_port'],
-        messages_type: fluent_config['messages_type'],
-      }
+      if (0 == settings.length)
+        fluent_config = if ENV["FLUENTD_URL"]
+                          self.parse_url(ENV["FLUENTD_URL"])
+                        else
+                          YAML.load(ERB.new(config_file.read).result)[Rails.env]
+                        end
+        settings = {
+          tag:  fluent_config['tag'],
+          host: fluent_config['fluent_host'],
+          port: fluent_config['fluent_port'],
+          messages_type: fluent_config['messages_type'],
+        }
+      end
       level = SEV_LABEL.index(Rails.application.config.log_level.to_s.upcase)
       logger = ActFluentLoggerRails::FluentLogger.new(settings, level, log_tags)
       logger = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
This makes it possible to have different rails fluent loggers logging to either different fluentd's or different tags or message type.

My use case is that I want a different tag for a logger for `ActiveRecord::Base.logger` and my primary logger.