### PR TITLE
Make Logger Map, Messages, and Tags Thread Safe

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -66,7 +66,7 @@ module ActFluentLoggerRails
     end
 
     def tagged(*tags)
-      @tags_thread_key ||= "activesupport_tagged_logging_tags:#{object_id}".freeze
+      @tags_thread_key ||= "fluentd_tagged_logging_tags:#{object_id}".freeze
       Thread.current[@tags_thread_key] = tags.flatten
       yield self
     ensure
@@ -87,9 +87,7 @@ module ActFluentLoggerRails
       logger_opts = {host: host, port: port, nanosecond_precision: nanosecond_precision}
       @fluent_logger = ::Fluent::Logger::FluentLogger.new(nil, logger_opts)
       @severity = 0
-      @messages = []
       @log_tags = log_tags
-      @map = {}
       after_initialize if respond_to? :after_initialize
     end
 
@@ -116,45 +114,55 @@ module ActFluentLoggerRails
         end
 
       if message.encoding == Encoding::UTF_8
-        @messages << message
+        logger_messages << message
       else
-        @messages << message.dup.force_encoding(Encoding::UTF_8)
+        logger_messages << message.dup.force_encoding(Encoding::UTF_8)
       end
 
       flush if @flush_immediately
     end
 
     def [](key)
-      @map[key]
+      map[key]
     end
 
     def []=(key, value)
-      @map[key] = value
+      map[key] = value
     end
 
     def flush
-      return if @messages.empty?
+      return if logger_messages.empty?
       messages = if @messages_type == :string
-                   @messages.join("\n")
+                   logger_messages.join("\n")
                  else
-                   @messages
+                   logger_messages
                  end
-      @map[:messages] = messages
-      @map[@severity_key] = format_severity(@severity)
+      map[:messages] = messages
+      map[@severity_key] = format_severity(@severity)
       add_tags
 
-      @fluent_logger.post(@tag, @map)
+      @fluent_logger.post(@tag, map)
       @severity = 0
-      @messages.clear
+      logger_messages.clear
       Thread.current[@tags_thread_key] = nil if @tags_thread_key
-      @map.clear
+      map.clear
     end
 
     def add_tags
-      return unless @tags_thread_key && Thread.current[@tags_thread_key]
+      return unless @tags_thread_key && Thread.current.key?(@tags_thread_key)
       @log_tags.keys.zip(Thread.current[@tags_thread_key]).each do |k, v|
-        @map[k] = v
+        map[k] = v
       end
+    end
+
+    def logger_messages
+      @messages_thread_key ||= "fluentd_logger_messages:#{object_id}".freeze
+      Thread.current[@messages_thread_key] ||= []
+    end
+
+    def map
+      @map_thread_key ||= "fluentd_logger_map:#{object_id}".freeze
+      Thread.current[@map_thread_key] ||= {}
     end
 
     def close


### PR DESCRIPTION
The current method of persisting log_tags using the [`@tags` variable](https://github.com/actindi/act-fluent-logger-rails/blob/master/lib/act-fluent-logger-rails/logger.rb#L69) is not thread safe. This PR changes the storage of those tags from being an instance variable to being stored in the current thread similar to [how active_support's tagged_logging](https://github.com/rails/rails/blob/89fab56597c335bb49887563b9a98386b5171574/activesupport/lib/active_support/tagged_logging.rb#L48) works.

When updating the tags I also found that `@map` and `@messages` were also both not thread safe so I applied a similar approach to those values as well to make them thread safe. I choose not to change the other instance variables which keep track of the logging options because those seem like they would be env specific and therefore constant among threads.   