### PR TITLE
Stop calling after_initialize in rails 6.0 or above

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -89,7 +89,7 @@ module ActFluentLoggerRails
       @messages = []
       @log_tags = log_tags
       @map = {}
-      after_initialize if respond_to? :after_initialize
+      after_initialize if respond_to? :after_initialize && Rails::VERSION::MAJOR < 6
     end
 
     def add(severity, message = nil, progname = nil, &block)


### PR DESCRIPTION
```
DEPRECATION WARNING: Logger don't need to call #after_initialize directly anymore. It will be
deprecated without replacement in Rails 6.1. (called from initialize at .../lib/act-fluent-logger-rails/logger.rb:92)
```