### PR TITLE
Adds support for properly logging Arrays

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -69,7 +69,7 @@ module ActFluentLoggerRails
 
     def tagged(*tags)
       @tags_thread_key ||= "fluentd_tagged_logging_tags:#{object_id}".freeze
-      Thread.current[@tags_thread_key] = tags.flatten
+      Thread.current[@tags_thread_key] = tags.length == 1 ? tags.flatten(1) : tags
       yield self
     ensure
       flush


### PR DESCRIPTION
Hello! Thank you for providing this gem. I noticed a possible issue in my team's usage of it. Without this patch, an Array will be flattened, resulting in keys and values becoming mismatched.

Eg, given a request that responds to `some_array_method` with `[1,2]`:
```
logger = Fluent::Logger::FluentLogger.new
logger.tagged(array: :some_array_method, date: Date.today)
```
You might expect to see log entries having tags like:

```
{ array: [1,2], date: '2021-07-20' }
```

but it will actually have tags like:

```
{ array: 1, date: 2}
```

This can be worked around by passing a proc which calls `to_s` on any array values,
but it seems unlikely users would expect their keys to map to different values if some method returns an Array.